### PR TITLE
Fix/background with server time

### DIFF
--- a/apps/web/src/components/WallBackgroundCanvas.tsx
+++ b/apps/web/src/components/WallBackgroundCanvas.tsx
@@ -18,10 +18,15 @@ interface WallBackgroundCanvasProps {
     layer: BackgroundLayer;
     col: number;
     row: number;
+    getNow: () => number;
 }
 
-export function WallBackgroundCanvas({ layer, col, row }: WallBackgroundCanvasProps) {
+export function WallBackgroundCanvas({ layer, col, row, getNow }: WallBackgroundCanvasProps) {
     const canvasRef = useRef<HTMLCanvasElement>(null);
+    const playerRef = useRef(getNow);
+    if (playerRef.current === null) {
+        playerRef.current = getNow;
+    }
 
     useEffect(() => {
         if (layer.backgroundType === 'solid') {
@@ -37,9 +42,7 @@ export function WallBackgroundCanvas({ layer, col, row }: WallBackgroundCanvasPr
         const isWaveBackground = layer.backgroundType === 'waves';
         const isParticleBackground = layer.backgroundType === 'particle';
         const draw = () => {
-            // t is derived from wall-clock time so all screens are always in sync.
-            // Tiny increments mean adjacent frames are nearly identical → smooth drift.
-            const t = (Date.now() / 1000) * BACKGROUND_T_SPEED * layer.speedFactor;
+            const t = (getNowRef.current() / 1000) * BACKGROUND_T_SPEED * layer.speedFactor;
             if (isWaveBackground) {
                 renderBackgroundWaves(canvasRef.current!, layer, col, row, t);
             } else if (isParticleBackground) {

--- a/apps/web/src/components/WallBackgroundCanvas.tsx
+++ b/apps/web/src/components/WallBackgroundCanvas.tsx
@@ -23,10 +23,10 @@ interface WallBackgroundCanvasProps {
 
 export function WallBackgroundCanvas({ layer, col, row, getNow }: WallBackgroundCanvasProps) {
     const canvasRef = useRef<HTMLCanvasElement>(null);
-    const playerRef = useRef(getNow);
-    if (playerRef.current === null) {
-        playerRef.current = getNow;
-    }
+    const getNowRef = useRef(getNow);
+    useEffect(() => {
+        getNowRef.current = getNow;
+    }, [getNow]);
 
     useEffect(() => {
         if (layer.backgroundType === 'solid') {

--- a/apps/web/src/routes/wall/index.tsx
+++ b/apps/web/src/routes/wall/index.tsx
@@ -836,6 +836,7 @@ function WallApp() {
                     layer={backgroundLayer}
                     col={myViewport.x / SCREEN_W}
                     row={myViewport.y / SCREEN_H}
+                    getNow={engine ? () => engine.getServerTime() : Date.now}
                 />
             )}
             {stageContent}


### PR DESCRIPTION
Change WallBackgroundCanvas to use server time so there is only one source of truth for time and thus the background flow could sync, fallback to use local machine time.