### PR TITLE
Fix/named assets

### DIFF
--- a/apps/web/src/components/AssetLibraryPanel.tsx
+++ b/apps/web/src/components/AssetLibraryPanel.tsx
@@ -102,6 +102,7 @@ export function AssetLibraryPanel({
 
         const layerBase = {
             numericId,
+            name: asset.name,
             url: `/api/assets/${asset.url}`,
             config,
             isUploading: false,

--- a/apps/web/src/components/AssetLibraryPanel.tsx
+++ b/apps/web/src/components/AssetLibraryPanel.tsx
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
 import { EditorEngine } from '~/lib/editorEngine';
 import { useEditorStore } from '~/lib/editorStore';
 import { fitSizeToViewport } from '~/lib/fitSizeToViewport';
-import { stripFileExtension } from '~/lib/mediaUtils';
+import { stripFileExtension, makeUniqueLayerName } from '~/lib/mediaUtils';
 import type { Layer, LayerWithEditorState } from '~/lib/types';
 import { $deleteAsset } from '~/server/projects.fns';
 
@@ -101,9 +101,14 @@ export function AssetLibraryPanel({
             anchorServerTime: engine.getServerTime()
         };
 
+        const layerName = makeUniqueLayerName(
+            stripFileExtension(asset.name),
+            Array.from(store.layers.values()).map((layer) => layer.name)
+        );
+
         const layerBase = {
             numericId,
-            name: stripFileExtension(asset.name),
+            name: layerName,
             url: `/api/assets/${asset.url}`,
             config,
             isUploading: false,

--- a/apps/web/src/components/AssetLibraryPanel.tsx
+++ b/apps/web/src/components/AssetLibraryPanel.tsx
@@ -4,6 +4,7 @@ import { useCallback } from 'react';
 import { EditorEngine } from '~/lib/editorEngine';
 import { useEditorStore } from '~/lib/editorStore';
 import { fitSizeToViewport } from '~/lib/fitSizeToViewport';
+import { stripFileExtension } from '~/lib/mediaUtils';
 import type { Layer, LayerWithEditorState } from '~/lib/types';
 import { $deleteAsset } from '~/server/projects.fns';
 
@@ -102,7 +103,7 @@ export function AssetLibraryPanel({
 
         const layerBase = {
             numericId,
-            name: asset.name,
+            name: stripFileExtension(asset.name),
             url: `/api/assets/${asset.url}`,
             config,
             isUploading: false,

--- a/apps/web/src/components/EditorSlate.tsx
+++ b/apps/web/src/components/EditorSlate.tsx
@@ -604,6 +604,7 @@ export function EditorSlate() {
         const optimisticLayer = {
             numericId,
             type: isImage ? 'image' : 'video',
+            name: file.name,
             url: previewDataUrl,
             playback: defaultPlayback,
             config,
@@ -655,6 +656,7 @@ export function EditorSlate() {
                 type: file.type,
                 data: file,
                 meta: {
+                    filename: file.name,
                     numericId: numericId.toString(),
                     duration: duration.toString(),
                     projectId: currentProjectId,
@@ -696,6 +698,7 @@ export function EditorSlate() {
                 layer: {
                     numericId,
                     type: finalizedLayer.type,
+                    name: finalizedLayer.name,
                     playback: defaultPlayback,
                     url: assetUrl,
                     config: freshestLayer.config

--- a/apps/web/src/components/EditorSlate.tsx
+++ b/apps/web/src/components/EditorSlate.tsx
@@ -33,7 +33,7 @@ import { EditorEngine } from '~/lib/editorEngine';
 import { getDOGridLines } from '~/lib/editorHelpers';
 import { useEditorStore } from '~/lib/editorStore';
 import { fitSizeToViewport, MIN_LAYER_DIMENSION } from '~/lib/fitSizeToViewport';
-import { isFontAsset, stripFileExtension } from '~/lib/mediaUtils';
+import { isFontAsset, stripFileExtension, makeUniqueLayerName } from '~/lib/mediaUtils';
 import { COLS, ROWS, SCREEN_H, SCREEN_W, SNAP_GRID } from '~/lib/stageConstants';
 import {
     getAngle,
@@ -601,10 +601,16 @@ export function EditorSlate() {
         };
 
         // 2. OPTIMISTIC UPDATE — mount immediately
+
+        const layerName = makeUniqueLayerName(
+            stripFileExtension(file.name),
+            Array.from(layersRef.current.values()).map((layer) => layer.name)
+        );
+
         const optimisticLayer = {
             numericId,
             type: isImage ? 'image' : 'video',
-            name: stripFileExtension(file.name),
+            name: layerName,
             url: previewDataUrl,
             playback: defaultPlayback,
             config,

--- a/apps/web/src/components/EditorSlate.tsx
+++ b/apps/web/src/components/EditorSlate.tsx
@@ -33,7 +33,7 @@ import { EditorEngine } from '~/lib/editorEngine';
 import { getDOGridLines } from '~/lib/editorHelpers';
 import { useEditorStore } from '~/lib/editorStore';
 import { fitSizeToViewport, MIN_LAYER_DIMENSION } from '~/lib/fitSizeToViewport';
-import { isFontAsset } from '~/lib/mediaUtils';
+import { isFontAsset, stripFileExtension } from '~/lib/mediaUtils';
 import { COLS, ROWS, SCREEN_H, SCREEN_W, SNAP_GRID } from '~/lib/stageConstants';
 import {
     getAngle,
@@ -604,7 +604,7 @@ export function EditorSlate() {
         const optimisticLayer = {
             numericId,
             type: isImage ? 'image' : 'video',
-            name: file.name,
+            name: stripFileExtension(file.name),
             url: previewDataUrl,
             playback: defaultPlayback,
             config,

--- a/apps/web/src/components/LayerItem.tsx
+++ b/apps/web/src/components/LayerItem.tsx
@@ -69,9 +69,9 @@ export function LayerItem({ layer, isSelected }: LayerItemProps) {
             case 'text':
                 return layer.textHtml.replace(/<[^>]*>/g, '').slice(0, 40) || 'Text';
             case 'image':
-                return 'Image';
+                return layer.name || 'Image';
             case 'video':
-                return 'Video';
+                return layer.name || 'Video';
             case 'graph':
                 return 'Graph';
             case 'map':

--- a/apps/web/src/components/LayerItem.tsx
+++ b/apps/web/src/components/LayerItem.tsx
@@ -65,6 +65,8 @@ export function LayerItem({ layer, isSelected }: LayerItemProps) {
     };
 
     const getLayerName = (layer: LayerWithEditorState): string => {
+        if (layer.name) return layer.name;
+
         switch (layer.type) {
             case 'text':
                 return layer.textHtml.replace(/<[^>]*>/g, '').slice(0, 40) || 'Text';

--- a/apps/web/src/lib/editorStore.layers.ts
+++ b/apps/web/src/lib/editorStore.layers.ts
@@ -1,6 +1,7 @@
 import { EditorEngine } from './editorEngine';
 import type { EditorState, SliceHelpers } from './editorStore.types';
 import { fitSizeToViewport, MIN_LAYER_DIMENSION } from './fitSizeToViewport';
+import { makeUniqueLayerName } from './mediaUtils';
 import { COLS, ROWS, SCREEN_H, SCREEN_W } from './stageConstants';
 import type { Layer, LayerWithEditorState } from './types';
 
@@ -10,6 +11,12 @@ type SliceSet = (
 type SliceGet = () => EditorState;
 
 export function createLayerSlice(set: SliceSet, get: SliceGet, helpers: SliceHelpers) {
+    const getUniqueLayerName = (baseName: string) =>
+        makeUniqueLayerName(
+            baseName,
+            Array.from(get().layers.values()).map((layer) => layer.name)
+        );
+
     return {
         hydrate: (layers: LayerWithEditorState[]) => {
             const engine = EditorEngine.getInstance();
@@ -327,6 +334,7 @@ export function createLayerSlice(set: SliceSet, get: SliceGet, helpers: SliceHel
 
             const newLayer: LayerWithEditorState = {
                 numericId,
+                name: getUniqueLayerName('Text'),
                 type: 'text',
                 config: {
                     cx: insertionCenter.x,
@@ -369,6 +377,7 @@ export function createLayerSlice(set: SliceSet, get: SliceGet, helpers: SliceHel
 
             const newLayer: LayerWithEditorState = {
                 numericId,
+                name: getUniqueLayerName('Map'),
                 type: 'map',
                 config: {
                     cx: insertionCenter.x,
@@ -417,6 +426,7 @@ export function createLayerSlice(set: SliceSet, get: SliceGet, helpers: SliceHel
 
             const newLayer: LayerWithEditorState = {
                 numericId,
+                name: getUniqueLayerName('Web'),
                 type: 'web',
                 config: {
                     cx: insertionCenter.x,
@@ -469,6 +479,7 @@ export function createLayerSlice(set: SliceSet, get: SliceGet, helpers: SliceHel
 
             const newLayer: LayerWithEditorState = {
                 numericId,
+                name: getUniqueLayerName('Shape Layer'),
                 type: 'shape',
                 shape,
                 config: {
@@ -582,6 +593,7 @@ export function createLayerSlice(set: SliceSet, get: SliceGet, helpers: SliceHel
 
             const newLayer: LayerWithEditorState = {
                 numericId,
+                name: getUniqueLayerName('Line'),
                 type: 'line',
                 config: {
                     cx,

--- a/apps/web/src/lib/mediaUtils.ts
+++ b/apps/web/src/lib/mediaUtils.ts
@@ -20,3 +20,10 @@ export function sortAssetsFontsLast<T extends { name: string; mimeType?: string 
     }
     return [...media, ...fonts];
 }
+
+export function stripFileExtension(name: string): string {
+    const trimmed = name.trim();
+    const dot = trimmed.lastIndexOf('.');
+    if (dot <= 0) return trimmed;
+    return trimmed.slice(0, dot);
+}

--- a/apps/web/src/lib/mediaUtils.ts
+++ b/apps/web/src/lib/mediaUtils.ts
@@ -27,3 +27,21 @@ export function stripFileExtension(name: string): string {
     if (dot <= 0) return trimmed;
     return trimmed.slice(0, dot);
 }
+
+export function makeUniqueLayerName(baseName: string, existingNames: Iterable<string | undefined>) {
+    const trimmedBase = baseName.trim() || 'Untitled';
+    const usedNames = new Set(
+        Array.from(existingNames)
+            .map((name) => name?.trim())
+            .filter((name): name is string => Boolean(name))
+    );
+
+    if (!usedNames.has(trimmedBase)) return trimmedBase;
+
+    let suffix = 1;
+    while (usedNames.has(`${trimmedBase} ${suffix}`)) {
+        suffix += 1;
+    }
+
+    return `${trimmedBase} ${suffix}`;
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -41,7 +41,11 @@ const LayerPlaybackStateSchema = z.object({
     anchorServerTime: z.number()
 });
 
-const LayerBaseSchema = z.object({ numericId: z.number(), config: LayerConfigStateSchema });
+const LayerBaseSchema = z.object({
+    numericId: z.number(),
+    name: z.string().optional(),
+    config: LayerConfigStateSchema
+});
 
 // Legacy commits may store variant metadata in inconsistent shapes.
 // Normalize any non-array or non-numeric values to undefined.
@@ -58,7 +62,6 @@ const LayerSchema = z.discriminatedUnion('type', [
         .object({
             type: z.literal('video'),
             url: z.string(),
-            name: z.string().optional(),
             stillImage: z.string().optional(),
             loop: z.boolean(),
             duration: z.number(),
@@ -71,7 +74,6 @@ const LayerSchema = z.discriminatedUnion('type', [
         .object({
             type: z.literal('image'),
             url: z.string(),
-            name: z.string().optional(),
             blurhash: z.string().optional()
         })
         .extend(LayerBaseSchema.shape),

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -58,6 +58,7 @@ const LayerSchema = z.discriminatedUnion('type', [
         .object({
             type: z.literal('video'),
             url: z.string(),
+            name: z.string().optional(),
             stillImage: z.string().optional(),
             loop: z.boolean(),
             duration: z.number(),
@@ -70,6 +71,7 @@ const LayerSchema = z.discriminatedUnion('type', [
         .object({
             type: z.literal('image'),
             url: z.string(),
+            name: z.string().optional(),
             blurhash: z.string().optional()
         })
         .extend(LayerBaseSchema.shape),


### PR DESCRIPTION
## Summary
1. The layer list uses the uploaded file name instead of the generic Image/Video labels.
2. File extensions are hidden in the layer label, so `test.png` becomes `test`.
3. Repeated layers get unique names like `test`, `test 1`, `test 2`.

## Possible improvment
Let users rename layers directly in the layer list, so the generated media name can be replaced with a custom label ( matching the same functionality as in the Slides section).