### PR TITLE
fix: Persist customRenderCompat and customRenderProxy in project form

### DIFF
--- a/apps/web/src/routes/_auth/quarry/projects/$projectId/index.tsx
+++ b/apps/web/src/routes/_auth/quarry/projects/$projectId/index.tsx
@@ -48,6 +48,8 @@ function InfoTab() {
                     heroImages: project.heroImages,
                     customControlUrl: project.customControlUrl ?? '',
                     customRenderUrl: project.customRenderUrl ?? '',
+                    customRenderCompat: project.customRenderCompat ?? false,
+                    customRenderProxy: project.customRenderProxy ?? false,
                     collaborators: project.collaborators
                 }}
                 onSubmit={(data) => mutation.mutate({ ...data, id: projectId })}


### PR DESCRIPTION
The customRenderCompat and customRenderProxy option in the project form did not persist after refresh, so passing the actual value from the project to the field. 